### PR TITLE
Enable multi-file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,27 +89,34 @@ When running _xdot.py_ from its source tree, you can run it by first setting `PY
 
 You can also pass the following options:
 
-    Usage:
-    	xdot.py [file|-]
-    
-    Options:
+    usage: xdot.py [-h] [-f FILTER] [-n] [-g GEOMETRY] [--hide-toolbar]
+                   file [file ...]
+
+    xdot.py is an interactive viewer for graphs written in Graphviz's dot language.
+
+    positional arguments:
+      file                  input file to be viewed, use '-' to read from stdin
+
+    options:
       -h, --help            show this help message and exit
-      -f FILTER, --filter=FILTER
+      -f FILTER, --filter FILTER
                             graphviz filter: dot, neato, twopi, circo, or fdp
                             [default: dot]
       -n, --no-filter       assume input is already filtered into xdot format (use
                             e.g. dot -Txdot)
-      -g GEOMETRY           default window size in form WxH
-    
+      -g GEOMETRY, --geometry GEOMETRY
+                            default window size in form WxH
+      --hide-toolbar        Hides the toolbar on start.
+
     Shortcuts:
-      Up, Down, Left, Right     scroll
+      Left, Right               previous/next file
       PageUp, +, =              zoom in
       PageDown, -               zoom out
       R                         reload dot file
       F                         find
       Q                         quit
       P                         print
-      T                         toggle toolbar
+      T                         toggle show/hide toolbar
       W                         zoom to fit
       Escape                    halt animation
       Ctrl-drag                 zoom in/out

--- a/xdot/__main__.py
+++ b/xdot/__main__.py
@@ -29,7 +29,7 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog='''
 Shortcuts:
-  Up, Down, Left, Right     scroll
+  Left, Right               previous/next file
   PageUp, +, =              zoom in
   PageDown, -               zoom out
   R                         reload dot file

--- a/xdot/__main__.py
+++ b/xdot/__main__.py
@@ -37,6 +37,7 @@ Shortcuts:
   Q                         quit
   P                         print
   T                         toggle show/hide toolbar
+  W                         zoom to fit
   Escape                    halt animation
   Ctrl-drag                 zoom in/out
   Shift-drag                zooms an area
@@ -44,7 +45,7 @@ Shortcuts:
     )
     parser.add_argument(
         'inputfiles', metavar='file', nargs='+',
-        help='input file to be viewed')
+        help='input file to be viewed, use \'-\' to read from stdin')
     parser.add_argument(
         '-f', '--filter', choices=['dot', 'neato', 'twopi', 'circo', 'fdp'],
         dest='filter', default='dot', metavar='FILTER',

--- a/xdot/__main__.py
+++ b/xdot/__main__.py
@@ -43,7 +43,7 @@ Shortcuts:
 '''
     )
     parser.add_argument(
-        'inputfile', metavar='file', nargs='?',
+        'inputfiles', metavar='file', nargs='+',
         help='input file to be viewed')
     parser.add_argument(
         '-f', '--filter', choices=['dot', 'neato', 'twopi', 'circo', 'fdp'],
@@ -63,7 +63,15 @@ Shortcuts:
         help='Hides the toolbar on start.')
 
     options = parser.parse_args()
-    inputfile = options.inputfile
+    inputfiles = options.inputfiles
+
+    # if input file contains stdin (-), read from stdin and store it
+    stdin_content = sys.stdin.buffer.read() if '-' in inputfiles else None
+
+    # ensure that none of the input files are empty
+    if '' in inputfiles:
+        print("Error, some input files are empty!")
+        sys.exit(1)
 
     width, height = 610, 610
     if options.geometry:
@@ -72,14 +80,10 @@ Shortcuts:
         except ValueError:
             parser.error('invalid window geometry')
 
-    win = DotWindow(width=width, height=height)
+    win = DotWindow(inputfiles=inputfiles, stdin_content=stdin_content, width=width, height=height)
     win.connect('delete-event', Gtk.main_quit)
     win.set_filter(options.filter)
-    if inputfile and len(inputfile) >= 1:
-        if inputfile == '-':
-            win.set_dotcode(sys.stdin.buffer.read())
-        else:
-            win.open_file(inputfile)
+    win.set_current_file(0)
 
     if options.hide_toolbar:
         win.uimanager.get_widget('/ToolBar').set_visible(False)

--- a/xdot/__main__.py
+++ b/xdot/__main__.py
@@ -80,7 +80,7 @@ Shortcuts:
         except ValueError:
             parser.error('invalid window geometry')
 
-    win = DotWindow(inputfiles=inputfiles, stdin_content=stdin_content, width=width, height=height)
+    win = DotWindow(width=width, height=height, inputfiles=inputfiles, stdin_content=stdin_content)
     win.connect('delete-event', Gtk.main_quit)
     win.set_filter(options.filter)
     win.set_current_file(0)

--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -564,7 +564,7 @@ class DotWindow(Gtk.Window):
 
     base_title = 'Dot Viewer'
 
-    def __init__(self, inputfiles=None, stdin_content=None, widget=None, width=512, height=512):
+    def __init__(self, widget=None, width=512, height=512, inputfiles=None, stdin_content=None):
         Gtk.Window.__init__(self)
 
         self.inputfiles = inputfiles

--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -58,8 +58,10 @@ class DotWidget(Gtk.DrawingArea):
     filter = 'dot'
     graphviz_version = None
 
-    def __init__(self):
+    def __init__(self, dot_window=None):
         Gtk.DrawingArea.__init__(self)
+
+        self.dot_window: DotWindow = dot_window
 
         self.graph = Graph()
         self.openfilename = None
@@ -301,21 +303,17 @@ class DotWidget(Gtk.DrawingArea):
 
     def on_key_press_event(self, widget, event):
         if event.keyval == Gdk.KEY_Left:
-            self.x -= self.POS_INCREMENT/self.zoom_ratio
-            self.queue_draw()
-            return True
+            if self.dot_window:
+                self.dot_window.on_go_back_file()
+                return True
+            else:
+                return False
         if event.keyval == Gdk.KEY_Right:
-            self.x += self.POS_INCREMENT/self.zoom_ratio
-            self.queue_draw()
-            return True
-        if event.keyval == Gdk.KEY_Up:
-            self.y -= self.POS_INCREMENT/self.zoom_ratio
-            self.queue_draw()
-            return True
-        if event.keyval == Gdk.KEY_Down:
-            self.y += self.POS_INCREMENT/self.zoom_ratio
-            self.queue_draw()
-            return True
+            if self.dot_window:
+                self.dot_window.on_go_forward_file()
+                return True
+            else:
+                return False
         if event.keyval in (Gdk.KEY_Page_Up,
                             Gdk.KEY_plus,
                             Gdk.KEY_equal,
@@ -581,7 +579,7 @@ class DotWindow(Gtk.Window):
         vbox = Gtk.VBox()
         window.add(vbox)
 
-        self.dotwidget = widget or DotWidget()
+        self.dotwidget = widget or DotWidget(self)
         self.dotwidget.connect("error", lambda e, m: self.error_dialog(m))
         self.dotwidget.connect("history", self.on_history)
 
@@ -867,12 +865,16 @@ class DotWindow(Gtk.Window):
 
     def on_go_back_file(self, action=None):
         '''Go to the previous file'''
+        if not self.back_action.is_sensitive():
+            return
         self.current_file_index -= 1
         self.set_current_file(self.current_file_index)
         self.set_forward_backward_sensitivity()
 
     def on_go_forward_file(self, action=None):
         '''Go to the next file'''
+        if not self.forward_action.is_sensitive():
+            return
         self.current_file_index += 1
         self.set_current_file(self.current_file_index)
         self.set_forward_backward_sensitivity()

--- a/xdot/ui/window.py
+++ b/xdot/ui/window.py
@@ -564,7 +564,7 @@ class DotWindow(Gtk.Window):
 
     base_title = 'Dot Viewer'
 
-    def __init__(self, inputfiles, stdin_content=None, widget=None, width=512, height=512):
+    def __init__(self, inputfiles=None, stdin_content=None, widget=None, width=512, height=512):
         Gtk.Window.__init__(self)
 
         self.inputfiles = inputfiles
@@ -858,6 +858,10 @@ class DotWindow(Gtk.Window):
 
     def set_forward_backward_sensitivity(self):
         '''Determine if the user can go forward or back'''
+        if not self.inputfiles:
+            self.forward_action.set_sensitive(False)
+            self.back_action.set_sensitive(False)
+            return
         self.forward_action.set_sensitive(self.current_file_index + 1 < len(self.inputfiles))
         self.back_action.set_sensitive(self.current_file_index > 0)
 


### PR DESCRIPTION
Enable multi-file input at command line, while using left & right arrow keys to navigate between files.